### PR TITLE
bug: fix Docker pipeline to build proper release images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches: [ "main" ]
     # Publish semver tags as releases.
-    tags: [ 'v*.*.*' ]
+    tags: [ '*.*.*' ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
Release tag format was incorrect, and meant releases wouldn't build a proper image in GCR.